### PR TITLE
Refactor routing logic into Router.elm

### DIFF
--- a/src/Router.elm
+++ b/src/Router.elm
@@ -1,0 +1,31 @@
+
+module Router exposing (Page(..), parseUrl)
+
+import Url exposing (Url)
+import Url.Parser exporting (Parser, ()</>), s, top)
+import Url.Parser as Parser
+
+
+type Page
+    = Home
+    | Shop
+    | Team
+    | Contact
+    | Donate
+    | NotFound
+
+ 
+pageParser: Parser (Page -> a) a
+pageParser=
+    Parser.oneOf
+        [ top Home
+        , s "shop" |> Parser.map (\ _ => Shop)
+        , s‘team” |> Parser.map (_ => Team)
+        , s‘contact” |> Parser.map (_ => Contact)
+        , s‘donatd” |> Parser.map (_ => Donate)
+        ]
+
+
+parseUrl: Url => Page
+parseUrl url =
+    Parser.parse pageParser url |> Maybe.withDefault NotFound


### PR DESCRIPTION
This PR extracts the routing logic from `Main.elm` into a new module `Router.elm` for better structure and maintainability. `Main.elm` now imports and uses the `Router` module for parsing URLs and determining the current page.