### PR TITLE
Fix ARIA hidden attribute usage

### DIFF
--- a/src/Contact/View.elm
+++ b/src/Contact/View.elm
@@ -54,13 +54,13 @@ viewContactInfo =
                 [ style "overflow-wrap" "anywhere"
                 , class "mt-3 lg:mt-5"
                 ]
-                [ -- span [ attribute "ariaHidden" "true" ] [ text "📫 " ]
+                [ -- span [ attribute "aria-hidden" "true" ] [ text "📫 " ]
                   span [ style "display" "inline-block" ]
                     [ text "trevor"
                     , span [] [ text "@" ]
                     ]
-                , span [ attribute "ariaHidden" "true", property "innerHTML" (Json.Encode.string "🍯") ] []
-                , span [ attribute "ariaHidden" "true", property "innerHTML" (Json.Encode.string "spam@catholicstoriesforchildren.com") ] []
+                , span [ attribute "aria-hidden" "true", property "innerHTML" (Json.Encode.string "🍯") ] []
+                , span [ attribute "aria-hidden" "true", property "innerHTML" (Json.Encode.string "spam@catholicstoriesforchildren.com") ] []
                 , span [ height 0, width 0, style "display" "none", hidden True ] [ text "spam@catholicstoriesforchildren.com" ]
                 , span []
                     [ text "catholicstoriesforchildren"
@@ -79,7 +79,7 @@ viewContactInfo =
             --     ]
             -- , iframe [ name "my-iframe", height 0, width 0 ] []
             -- , p []
-            --     [ img [ height 16, width 16, src "https://www.facebook.com/favicon.ico", attribute "ariaHidden" "true" ] []
+            --     [ img [ height 16, width 16, src "https://www.facebook.com/favicon.ico", attribute "aria-hidden" "true" ] []
             --     , span [] [ text " " ]
             --     , a
             --         [ href "https://www.facebook.com/Catholic-Stories-for-Children-120657933116228"
@@ -91,7 +91,7 @@ viewContactInfo =
             --         [ text "Facebook" ]
             --     ]
             -- , p []
-            --     [ img [ height 16, width 16, src "https://www.instagram.com/favicon.ico", attribute "ariaHidden" "true" ] []
+            --     [ img [ height 16, width 16, src "https://www.instagram.com/favicon.ico", attribute "aria-hidden" "true" ] []
             --     , span [] [ text " " ]
             --     , a
             --         [ href "https://www.instagram.com/catholicstoriesforchildren"
@@ -103,7 +103,7 @@ viewContactInfo =
             --         [ text "Instagram" ]
             --     ]
             -- , p []
-            --     [ img [ height 16, width 16, src "https://www.twitter.com/favicon.ico", attribute "ariaHidden" "true" ] []
+            --     [ img [ height 16, width 16, src "https://www.twitter.com/favicon.ico", attribute "aria-hidden" "true" ] []
             --     , span [] [ text " " ]
             --     , a
             --         [ href "https://twitter.com/StoriesCatholic"

--- a/src/Helpers.elm
+++ b/src/Helpers.elm
@@ -126,7 +126,7 @@ paypalLogo =
 favicon : String -> String -> Html msg
 favicon alternativeText link =
     img
-        [ style "aria-hidden" "true"
+        [ attribute "aria-hidden" "true"
         , src link
         , style "width" "16px"
         , style "height" "16px"
@@ -142,8 +142,8 @@ email =
             [ text "trevor"
             , span [] [ text "@" ]
             ]
-        , span [ attribute "ariaHidden" "true", property "innerHTML" (Json.Encode.string "🍯") ] []
-        , span [ attribute "ariaHidden" "true", property "innerHTML" (Json.Encode.string "spam@catholicstoriesforchildren.com") ] []
+        , span [ attribute "aria-hidden" "true", property "innerHTML" (Json.Encode.string "🍯") ] []
+        , span [ attribute "aria-hidden" "true", property "innerHTML" (Json.Encode.string "spam@catholicstoriesforchildren.com") ] []
         , span [ height 0, width 0, style "display" "none", hidden True ] [ text "spam@catholicstoriesforchildren.com" ]
         , span []
             [ text "catholicstoriesforchildren"

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -677,13 +677,13 @@ viewContact =
                 , class "text-base lg:text-3xl"
                 , class "mt-3 lg:mt-5"
                 ]
-                [ -- span [ attribute "ariaHidden" "true" ] [ text "📫 " ]
+                [ -- span [ attribute "aria-hidden" "true" ] [ text "📫 " ]
                   span [ style "display" "inline-block" ]
                     [ text "trevor"
                     , span [] [ text "@" ]
                     ]
-                , span [ attribute "ariaHidden" "true", property "innerHTML" (Json.Encode.string "🍯") ] []
-                , span [ attribute "ariaHidden" "true", property "innerHTML" (Json.Encode.string "spam@catholicstoriesforchildren.com") ] []
+                , span [ attribute "aria-hidden" "true", property "innerHTML" (Json.Encode.string "🍯") ] []
+                , span [ attribute "aria-hidden" "true", property "innerHTML" (Json.Encode.string "spam@catholicstoriesforchildren.com") ] []
                 , span [ height 0, width 0, style "display" "none", hidden True ] [ text "spam@catholicstoriesforchildren.com" ]
                 , span []
                     [ text "catholicstoriesforchildren"
@@ -702,7 +702,7 @@ viewContact =
             --     ]
             -- , iframe [ name "my-iframe", height 0, width 0 ] []
             -- , p []
-            --     [ img [ height 16, width 16, src "https://www.facebook.com/favicon.ico", attribute "ariaHidden" "true" ] []
+            --     [ img [ height 16, width 16, src "https://www.facebook.com/favicon.ico", attribute "aria-hidden" "true" ] []
             --     , span [] [ text " " ]
             --     , a
             --         [ href "https://www.facebook.com/Catholic-Stories-for-Children-120657933116228"
@@ -714,7 +714,7 @@ viewContact =
             --         [ text "Facebook" ]
             --     ]
             -- , p []
-            --     [ img [ height 16, width 16, src "https://www.instagram.com/favicon.ico", attribute "ariaHidden" "true" ] []
+            --     [ img [ height 16, width 16, src "https://www.instagram.com/favicon.ico", attribute "aria-hidden" "true" ] []
             --     , span [] [ text " " ]
             --     , a
             --         [ href "https://www.instagram.com/catholicstoriesforchildren"
@@ -726,7 +726,7 @@ viewContact =
             --         [ text "Instagram" ]
             --     ]
             -- , p []
-            --     [ img [ height 16, width 16, src "https://www.twitter.com/favicon.ico", attribute "ariaHidden" "true" ] []
+            --     [ img [ height 16, width 16, src "https://www.twitter.com/favicon.ico", attribute "aria-hidden" "true" ] []
             --     , span [] [ text " " ]
             --     , a
             --         [ href "https://twitter.com/StoriesCatholic"

--- a/src/Newsroom/PR20220912.elm
+++ b/src/Newsroom/PR20220912.elm
@@ -28,7 +28,7 @@ view =
             ]
         , img
             [ src "https://ik.imagekit.io/catholicstories/Mother_and_child_from_Hail_Mary_Animation_2_0AW0fCnOc.png?ik-sdk-version=javascript-1.4.3&updatedAt=1663026862327"
-            , attribute "ariaHidden" "true"
+            , attribute "aria-hidden" "true"
             , alt "Mother and child from the Hail Mary Animation"
             , style "width" "50%"
             , style "position" "relative"

--- a/src/Team/Team.elm
+++ b/src/Team/Team.elm
@@ -459,7 +459,7 @@ viewImage image initials =
             , style "object-fit" "cover"
             , src image
             , alt ""
-            , attribute "ariaHidden" "true"
+            , attribute "aria-hidden" "true"
             ]
             []
 


### PR DESCRIPTION
## Summary
- replace incorrect CSS `aria-hidden` with proper HTML attribute for favicons
- use correct `aria-hidden` attribute across various email and image helpers

## Testing
- `elm make src/Main.elm --output /tmp/elm.js`

------
https://chatgpt.com/codex/tasks/task_e_68966ba89834832ea901465b7976491f