### PR TITLE
Add build-time prerendering for crawlable HTML on public routes (#34)

### DIFF
--- a/docs/SEO_PRERENDERING.md
+++ b/docs/SEO_PRERENDERING.md
@@ -1,0 +1,82 @@
+# Build-time prerendering for crawlable HTML
+
+## Problem
+
+`claritasstudios.com` is an Elm SPA bundled with Vite. Before this change,
+every public route returned the same shell `index.html` whose body contained
+only `<div id="elm-root"></div>` plus the bundle. Crawlers and AI retrievers
+that read raw HTML — Google's initial pass, Bing, Perplexity, ChatGPT
+browsing, Claude browsing, Gemini, and link-preview bots — saw no headings,
+no copy, no internal links, and no per-route metadata.
+
+The SEO/GEO audit (`/home/user/workspace/claritasstudios_seo_geo_findings.md`)
+flagged this as the highest-priority issue and recommended choosing one of
+SSG, SSR, build-time prerendering, or a prerender bridge.
+
+## Decision: build-time prerendering
+
+We chose **build-time prerendering** — least disruptive of the four options
+for this codebase.
+
+| Option | Why not |
+|---|---|
+| Full SSG (rewrite in Next.js / Astro / Elm Pages) | Touches the entire app; the whole product is Elm; weeks of work. |
+| SSR | Requires a Node server in front of static hosting (Netlify); breaks the current static deploy. |
+| Prerender bridge (Prerender.io / Rendertron) | Adds a runtime dependency, ongoing cost, and another point of failure. Crawler-only — humans still get the slow SPA shell. |
+| **Build-time prerender (chosen)** | Pure additive Node script; runs after `vite build`; outputs one static `index.html` per public route; SPA still hydrates for users; no infra changes. |
+
+## How it works
+
+1. `scripts/seo-routes.mjs` is the single source of truth for route
+   metadata (path, `<title>`, description, canonical, H1, intro copy,
+   per-section paragraphs and links).
+2. `scripts/prerender-routes.mjs` runs after `vite build`. For each route
+   it:
+   - reads `dist/index.html` (the SPA shell Vite produced),
+   - rewrites `<title>`, meta description, OG tags,
+   - inserts `<link rel="canonical">` and `twitter:title` / `twitter:description`,
+   - injects route-specific H1, intro paragraph, primary navigation, and
+     deep links inside the `<div id="elm-root">` mount node,
+   - writes `dist/<route>/index.html`.
+3. `scripts/verify-seo.mjs` reads every emitted file and asserts that each
+   has exactly one `<title>`, one canonical, at least one H1, a non-empty
+   meta description, and at least one internal link. Run with
+   `npm run verify:seo`. Exits non-zero on failure so it can run in CI.
+4. The Elm bundle still loads for end users. When `Elm.Main.init` mounts on
+   `#elm-root` it replaces the prerendered children with the live Elm view —
+   so users see the same interactive experience as before. Crawlers and
+   `curl` see the prerendered HTML.
+
+## Routes covered
+
+Required (per issue #34): `/`, `/animations/`, `/team/`, `/resources/`,
+`/give/`, `/contact/`, `/saints/`, `/prayers/`, `/feastdayactivities/`.
+
+Animation series (discovered in `src/Page/Animations/Productions.elm`):
+`/animations/hailmary/`, `/animations/prayertimewithangels/`,
+`/animations/daisyandsheep/`, `/animations/songsofthesaints/`,
+`/animations/gigglesandgraceshow/`, `/animations/prayingwiththesaints/`.
+
+Individual episode pages and saint detail pages remain SPA-only. The
+saint detail pages are deliberately `noindex` (see `index.html`) and
+episode URLs change frequently as new content lands. A follow-up issue
+can drive these into the prerender pipeline once the metadata schema
+stabilizes.
+
+## Adding a new public route
+
+1. Add an entry to `ROUTES` in `scripts/seo-routes.mjs`.
+2. Run `npm run build`. The new file appears at `dist/<path>/index.html`.
+3. Run `npm run verify:seo` to confirm.
+4. Add the URL to `public/static/sitemap.xml`.
+
+## Verification
+
+```bash
+npm run build           # vite build + prerender
+npm run verify:seo      # SEO smoke test on dist/
+
+# Manual spot check:
+cd dist && python3 -m http.server 8765 &
+curl -s http://localhost:8765/animations/ | grep -E '<title>|<h1>|name="description"|canonical'
+```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "build.js",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && npm run prerender",
+    "prerender": "node scripts/prerender-routes.mjs",
+    "verify:seo": "node scripts/verify-seo.mjs",
     "preview": "vite preview",
     "start": "npm run dev"
   },

--- a/public/static/robots.txt
+++ b/public/static/robots.txt
@@ -2,4 +2,4 @@ User-agent: *
 Allow: /
 Disallow: /saints?s=
 
-Sitemap: http://www.claritasstudios.com/sitemap.xml
+Sitemap: https://claritasstudios.com/sitemap.xml

--- a/public/static/sitemap.xml
+++ b/public/static/sitemap.xml
@@ -5,21 +5,48 @@
       xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
             http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
-
 <url>
   <loc>https://claritasstudios.com/</loc>
   <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://claritasstudios.com/team/</loc>
-  <priority>0.80</priority>
-</url>
-<url>
   <loc>https://claritasstudios.com/animations/</loc>
+  <priority>0.90</priority>
+</url>
+<url>
+  <loc>https://claritasstudios.com/animations/hailmary/</loc>
+  <priority>0.70</priority>
+</url>
+<url>
+  <loc>https://claritasstudios.com/animations/prayertimewithangels/</loc>
+  <priority>0.70</priority>
+</url>
+<url>
+  <loc>https://claritasstudios.com/animations/daisyandsheep/</loc>
+  <priority>0.70</priority>
+</url>
+<url>
+  <loc>https://claritasstudios.com/animations/songsofthesaints/</loc>
+  <priority>0.70</priority>
+</url>
+<url>
+  <loc>https://claritasstudios.com/animations/gigglesandgraceshow/</loc>
+  <priority>0.70</priority>
+</url>
+<url>
+  <loc>https://claritasstudios.com/animations/prayingwiththesaints/</loc>
+  <priority>0.70</priority>
+</url>
+<url>
+  <loc>https://claritasstudios.com/saints/</loc>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://claritasstudios.com/contact/</loc>
+  <loc>https://claritasstudios.com/prayers/</loc>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://claritasstudios.com/feastdayactivities/</loc>
   <priority>0.80</priority>
 </url>
 <url>
@@ -27,8 +54,16 @@
   <priority>0.70</priority>
 </url>
 <url>
+  <loc>https://claritasstudios.com/team/</loc>
+  <priority>0.70</priority>
+</url>
+<url>
   <loc>https://claritasstudios.com/give/</loc>
   <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://claritasstudios.com/contact/</loc>
+  <priority>0.70</priority>
 </url>
 
 </urlset>

--- a/scripts/prerender-routes.mjs
+++ b/scripts/prerender-routes.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+/*
+ * Build-time prerenderer for the Claritas Studios Elm SPA.
+ *
+ * For each public route, write a route-specific `index.html` into `dist/`
+ * that contains crawlable content (title, meta description, canonical,
+ * H1, navigation links, route-specific copy) BEFORE the Elm bundle runs.
+ *
+ * The Elm SPA still mounts on top of `<div id="elm-root">` after JS loads,
+ * so end-user behavior is unchanged. But crawlers and AI retrievers that
+ * read raw HTML now see meaningful content for each route.
+ *
+ * See docs/SEO_PRERENDERING.md for the design rationale.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { ROUTES, SITE_ORIGIN, NAV_LINKS } from './seo-routes.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const distDir = resolve(__dirname, '..', 'dist');
+const baseHtmlPath = resolve(distDir, 'index.html');
+
+if (!existsSync(baseHtmlPath)) {
+  console.error(`[prerender] Cannot find ${baseHtmlPath}. Run \`vite build\` first.`);
+  process.exit(1);
+}
+
+const baseHtml = readFileSync(baseHtmlPath, 'utf8');
+
+function escape(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function renderNav() {
+  const items = NAV_LINKS
+    .map((l) => `      <li><a href="${escape(l.href)}">${escape(l.label)}</a></li>`)
+    .join('\n');
+  return `  <nav aria-label="Primary">\n    <ul>\n${items}\n    </ul>\n  </nav>`;
+}
+
+function renderBodyContent(route) {
+  const sections = (route.sections || [])
+    .map((s) => {
+      const heading = s.heading ? `    <h2>${escape(s.heading)}</h2>\n` : '';
+      const paragraphs = (s.paragraphs || [])
+        .map((p) => `    <p>${escape(p)}</p>`)
+        .join('\n');
+      const links = (s.links || []).length
+        ? `    <ul>\n${s.links.map((l) => `      <li><a href="${escape(l.href)}">${escape(l.label)}</a></li>`).join('\n')}\n    </ul>`
+        : '';
+      return `  <section>\n${heading}${paragraphs}${links ? '\n' + links : ''}\n  </section>`;
+    })
+    .join('\n');
+
+  return [
+    `<noscript-seo data-route="${escape(route.path)}">`,
+    `  <header>`,
+    `    <a href="/">Claritas Studios</a>`,
+    `  </header>`,
+    renderNav(),
+    `  <main>`,
+    `    <h1>${escape(route.h1)}</h1>`,
+    `    <p>${escape(route.intro)}</p>`,
+    sections,
+    `  </main>`,
+    `  <footer>`,
+    `    <p>Claritas Studios &mdash; Catholic animations and resources for children.</p>`,
+    `    <ul>`,
+    `      <li><a href="/give/">Donate</a></li>`,
+    `      <li><a href="/contact/">Contact</a></li>`,
+    `      <li><a href="/about/privacy-policy">Privacy Policy</a></li>`,
+    `      <li><a href="/about/terms-and-conditions">Terms &amp; Conditions</a></li>`,
+    `    </ul>`,
+    `  </footer>`,
+    `</noscript-seo>`,
+  ].join('\n');
+}
+
+function renderRouteHtml(route) {
+  const canonical = `${SITE_ORIGIN}${route.path}`;
+  const title = route.title;
+  const description = route.description;
+  const ogImage = route.ogImage || `${SITE_ORIGIN}/assets/images/thumbnails/CSCThumbnail.png`;
+
+  let html = baseHtml;
+
+  // Replace <title>
+  html = html.replace(/<title>[\s\S]*?<\/title>/i, `<title>${escape(title)}</title>`);
+
+  // Replace meta description
+  html = html.replace(
+    /<meta\s+name="description"[\s\S]*?>/i,
+    `<meta name="description" content="${escape(description)}">`,
+  );
+
+  // Replace og:title
+  html = html.replace(
+    /<meta\s+property="og:title"[\s\S]*?>/i,
+    `<meta property="og:title" content="${escape(title)}">`,
+  );
+
+  // Replace og:description
+  html = html.replace(
+    /<meta\s+property="og:description"[\s\S]*?>/i,
+    `<meta property="og:description" content="${escape(description)}">`,
+  );
+
+  // Replace og:url
+  html = html.replace(
+    /<meta\s+property="og:url"[\s\S]*?>/i,
+    `<meta property="og:url" content="${escape(canonical)}">`,
+  );
+
+  // Replace og:image / twitter:image when route overrides it
+  html = html.replace(
+    /<meta\s+property="og:image"[\s\S]*?>/i,
+    `<meta property="og:image" content="${escape(ogImage)}">`,
+  );
+  html = html.replace(
+    /<meta\s+property="twitter:image"[\s\S]*?>/i,
+    `<meta property="twitter:image" content="${escape(ogImage)}">`,
+  );
+
+  // Add canonical link, twitter:title and twitter:description into <head>
+  // (insert just before </head>)
+  const headExtras = [
+    `  <link rel="canonical" href="${escape(canonical)}">`,
+    `  <meta property="twitter:title" content="${escape(title)}">`,
+    `  <meta property="twitter:description" content="${escape(description)}">`,
+  ].join('\n');
+  html = html.replace(/<\/head>/i, `${headExtras}\n</head>`);
+
+  // Inject crawlable content immediately inside #elm-root.
+  // Elm's Browser.application replaces the mount node when it boots, so
+  // this content is invisible to JS-enabled visitors but visible to crawlers
+  // and to anyone fetching raw HTML (curl, AI retrievers, link previewers).
+  const seoBody = renderBodyContent(route);
+  html = html.replace(
+    /<div id="elm-root"><\/div>/,
+    `<div id="elm-root">\n${seoBody}\n</div>`,
+  );
+
+  return html;
+}
+
+function writeRoute(route) {
+  const outPath = route.path === '/'
+    ? resolve(distDir, 'index.html')
+    : resolve(distDir, route.path.replace(/^\/+|\/+$/g, ''), 'index.html');
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, renderRouteHtml(route), 'utf8');
+  return outPath;
+}
+
+const written = ROUTES.map(writeRoute);
+console.log(`[prerender] Wrote ${written.length} route files:`);
+for (const p of written) {
+  console.log(`  - ${p.replace(distDir, 'dist')}`);
+}

--- a/scripts/seo-routes.mjs
+++ b/scripts/seo-routes.mjs
@@ -1,0 +1,308 @@
+/*
+ * Single source of truth for prerendered route metadata.
+ *
+ * Each entry produces one static `<path>/index.html` file at build time
+ * with route-specific <title>, meta description, canonical link, OG tags,
+ * H1, navigation, and crawlable text content.
+ *
+ * Edit this file when you add a new public route.
+ */
+
+export const SITE_ORIGIN = 'https://claritasstudios.com';
+
+export const NAV_LINKS = [
+  { href: '/', label: 'Home' },
+  { href: '/animations/', label: 'Animations' },
+  { href: '/saints/', label: 'Saints' },
+  { href: '/prayers/', label: 'Prayers' },
+  { href: '/feastdayactivities/', label: 'Feast Day Activities' },
+  { href: '/resources/', label: 'Resources' },
+  { href: '/team/', label: 'Team' },
+  { href: '/give/', label: 'Give' },
+  { href: '/contact/', label: 'Contact' },
+];
+
+const ANIMATION_SERIES = [
+  {
+    slug: 'hailmary',
+    title: 'Hail Mary',
+    description: 'Learn one of the most beautiful prayers in the Catholic tradition. A prayer of love and devotion to our Blessed Mother Mary.',
+    age: 'Ages 2+',
+    year: '2020',
+  },
+  {
+    slug: 'prayertimewithangels',
+    title: 'Prayer Time with Angels',
+    description: 'Join Theo and Felicity as they learn common Catholic prayers from their guardian angels.',
+    age: 'Ages 6+',
+    year: '2023',
+  },
+  {
+    slug: 'daisyandsheep',
+    title: 'Daisy and Sheep',
+    description: 'Join Daisy and Sheep as they learn about the Mass one part at a time and discover fun facts about the Catholic Church.',
+    age: 'Ages 10+',
+    year: '2024',
+  },
+  {
+    slug: 'songsofthesaints',
+    title: 'Songs of the Saints',
+    description: 'Sing along with your favorite saints in this musical journey.',
+    age: 'Ages 10+',
+    year: '2025',
+  },
+  {
+    slug: 'gigglesandgraceshow',
+    title: 'Giggles and Grace Show',
+    description: 'A musical animated short film that celebrates the joy of thanking God even when things go wrong.',
+    age: 'Ages 2+',
+    year: '2025',
+  },
+  {
+    slug: 'prayingwiththesaints',
+    title: 'Praying with the Saints',
+    description: 'Pray common prayers with the saints in this collection of 12 videos featuring St. Thérèse of Lisieux and Carlo Acutis.',
+    age: 'Ages 6+',
+    year: '2025',
+  },
+];
+
+function animationSeriesRoute(series) {
+  return {
+    path: `/animations/${series.slug}/`,
+    title: `${series.title} | Catholic Animations | Claritas Studios`,
+    description: series.description,
+    h1: series.title,
+    intro: `${series.description} ${series.age}. Released ${series.year}.`,
+    sections: [
+      {
+        heading: 'About this series',
+        paragraphs: [
+          series.description,
+          `Recommended for ${series.age}.`,
+        ],
+        links: [
+          { href: '/animations/', label: 'Browse all animations' },
+        ],
+      },
+    ],
+  };
+}
+
+export const ROUTES = [
+  {
+    path: '/',
+    title: 'Free Catholic Animations for Children | Claritas Studios',
+    description: 'Claritas Studios creates free Catholic animations, prayers, saint stories, and feast-day activities to help children grow in their love of God and neighbor.',
+    h1: 'Free Catholic Animations for Children',
+    intro: 'Claritas Studios is a Catholic nonprofit creating animated stories, prayers, and resources that help children encounter the beauty of the faith.',
+    sections: [
+      {
+        heading: 'Watch our animations',
+        paragraphs: [
+          'Our original animated series cover the rosary, the Mass, the saints, and core prayers of the Catholic tradition. Every video is free to watch and share.',
+        ],
+        links: [
+          { href: '/animations/hailmary/', label: 'Hail Mary' },
+          { href: '/animations/prayertimewithangels/', label: 'Prayer Time with Angels' },
+          { href: '/animations/daisyandsheep/', label: 'Daisy and Sheep' },
+          { href: '/animations/songsofthesaints/', label: 'Songs of the Saints' },
+          { href: '/animations/gigglesandgraceshow/', label: 'Giggles and Grace Show' },
+          { href: '/animations/prayingwiththesaints/', label: 'Praying with the Saints' },
+        ],
+      },
+      {
+        heading: 'Explore prayers, saints, and feast days',
+        paragraphs: [
+          'Beyond animation we publish printable prayers, saint biographies for kids, and seasonal feast-day activities families can use at home or in the classroom.',
+        ],
+        links: [
+          { href: '/prayers/', label: 'Catholic Prayers' },
+          { href: '/saints/', label: 'Lives of the Saints' },
+          { href: '/feastdayactivities/', label: 'Feast Day Activities' },
+          { href: '/resources/', label: 'Resources for Parents and Teachers' },
+        ],
+      },
+      {
+        heading: 'Support our mission',
+        paragraphs: [
+          'Claritas Studios is a 501(c)(3) Catholic nonprofit. Every donation helps us produce more free, faithful content for families.',
+        ],
+        links: [
+          { href: '/give/', label: 'Donate' },
+          { href: '/team/', label: 'Meet the team' },
+          { href: '/contact/', label: 'Contact us' },
+        ],
+      },
+    ],
+  },
+  {
+    path: '/animations/',
+    title: 'Catholic Animations for Kids | Claritas Studios',
+    description: 'Watch free Catholic animated series for children: Hail Mary, Prayer Time with Angels, Daisy and Sheep, Songs of the Saints, Giggles and Grace, and Praying with the Saints.',
+    h1: 'Catholic Animations for Kids',
+    intro: 'Browse every animated series produced by Claritas Studios. Each show is free to watch online and designed to nurture a child’s love of God and the saints.',
+    sections: [
+      {
+        heading: 'Series',
+        paragraphs: [
+          'Our catalog includes original short films and ongoing series for ages 2 and up.',
+        ],
+        links: ANIMATION_SERIES.map((s) => ({
+          href: `/animations/${s.slug}/`,
+          label: `${s.title} — ${s.age}`,
+        })),
+      },
+    ],
+  },
+  ...ANIMATION_SERIES.map(animationSeriesRoute),
+  {
+    path: '/team/',
+    title: 'About Our Catholic Animation Nonprofit | Claritas Studios',
+    description: 'Meet the team behind Claritas Studios. We are a Catholic nonprofit creating animated stories, prayers, and resources for children and families.',
+    h1: 'About Claritas Studios',
+    intro: 'Claritas Studios is a Catholic nonprofit. Our team of animators, writers, musicians, and theologians collaborates to make beautiful, faithful media for children.',
+    sections: [
+      {
+        heading: 'Our mission',
+        paragraphs: [
+          'We exist to help children encounter Jesus Christ through stories, prayer, and beauty. Every project is rooted in Catholic teaching and made for the whole family.',
+        ],
+      },
+      {
+        heading: 'Get involved',
+        paragraphs: [
+          'We are always looking for collaborators, partner parishes, and donors who share our mission.',
+        ],
+        links: [
+          { href: '/give/', label: 'Support our work' },
+          { href: '/contact/', label: 'Contact the team' },
+        ],
+      },
+    ],
+  },
+  {
+    path: '/resources/',
+    title: 'Catholic Resources for Parents and Teachers | Claritas Studios',
+    description: 'Free Catholic resources for parents, catechists, and teachers: printable activities, prayer guides, saint biographies, and feast-day worksheets.',
+    h1: 'Resources for Parents and Teachers',
+    intro: 'Free downloadable Catholic resources from Claritas Studios. Use these printables and guides at home, in the classroom, or in your parish faith-formation program.',
+    sections: [
+      {
+        heading: 'Browse by topic',
+        paragraphs: [
+          'Resources cover prayer, the Mass, the saints, the liturgical year, and the lives of children’s patron saints.',
+        ],
+        links: [
+          { href: '/prayers/', label: 'Prayers' },
+          { href: '/saints/', label: 'Saints' },
+          { href: '/feastdayactivities/', label: 'Feast Day Activities' },
+          { href: '/animations/', label: 'Animated series' },
+        ],
+      },
+    ],
+  },
+  {
+    path: '/give/',
+    title: 'Donate to Claritas Studios | Support Catholic Animation for Children',
+    description: 'Make a tax-deductible donation to Claritas Studios. Your gift funds free Catholic animations, prayers, and resources for families around the world.',
+    h1: 'Support Claritas Studios',
+    intro: 'Claritas Studios is a 501(c)(3) Catholic nonprofit. Donations are tax-deductible and directly fund the production of new animations and free resources.',
+    sections: [
+      {
+        heading: 'Why give',
+        paragraphs: [
+          'Every dollar helps us reach more children with beautiful, faithful storytelling. We keep our animations free so any family can watch.',
+        ],
+      },
+      {
+        heading: 'Other ways to help',
+        paragraphs: [
+          'Share our animations, pray for our team, or partner with us through your parish or school.',
+        ],
+        links: [
+          { href: '/contact/', label: 'Contact us about partnerships' },
+          { href: '/animations/', label: 'Watch and share our animations' },
+        ],
+      },
+    ],
+  },
+  {
+    path: '/contact/',
+    title: 'Contact Claritas Studios | Catholic Animation Studio',
+    description: 'Get in touch with Claritas Studios. We welcome partnership, press, and parish inquiries about our Catholic animations and resources.',
+    h1: 'Contact Claritas Studios',
+    intro: 'We love hearing from families, parishes, and schools who use our animations. Reach out with questions, partnership ideas, or press inquiries.',
+    sections: [
+      {
+        heading: 'Stay in touch',
+        paragraphs: [
+          'Subscribe to our newsletter for new releases, free downloads, and behind-the-scenes updates from our team.',
+        ],
+        links: [
+          { href: '/give/', label: 'Donate' },
+          { href: '/team/', label: 'Meet the team' },
+        ],
+      },
+    ],
+  },
+  {
+    path: '/saints/',
+    title: 'Lives of the Saints for Kids | Claritas Studios',
+    description: 'Read short Catholic saint biographies for children. Discover patron saints, feast days, and inspiring stories of faith from across the centuries.',
+    h1: 'Lives of the Saints',
+    intro: 'Browse short saint biographies written for children. Each entry includes the saint’s feast day and a kid-friendly summary of their life and witness.',
+    sections: [
+      {
+        heading: 'Discover the saints',
+        paragraphs: [
+          'From early martyrs to modern witnesses like Carlo Acutis, the lives of the saints show the many ways the Holy Spirit works in the world.',
+        ],
+        links: [
+          { href: '/feastdayactivities/', label: 'Feast Day Activities' },
+          { href: '/animations/songsofthesaints/', label: 'Songs of the Saints animation' },
+          { href: '/animations/prayingwiththesaints/', label: 'Praying with the Saints animation' },
+        ],
+      },
+    ],
+  },
+  {
+    path: '/prayers/',
+    title: 'Catholic Prayers for Children | Claritas Studios',
+    description: 'Learn classic Catholic prayers with your children: the Hail Mary, Our Father, Glory Be, Angelus, Act of Contrition, and more, paired with animated explainers.',
+    h1: 'Catholic Prayers for Children',
+    intro: 'A growing library of classic Catholic prayers in plain English, paired with our animations so children can both hear and pray each one.',
+    sections: [
+      {
+        heading: 'Featured prayers',
+        paragraphs: [
+          'Start with the prayers every Catholic child should know.',
+        ],
+        links: [
+          { href: '/animations/hailmary/', label: 'Hail Mary (animation)' },
+          { href: '/animations/prayertimewithangels/', label: 'Prayer Time with Angels' },
+          { href: '/animations/prayingwiththesaints/', label: 'Praying with the Saints' },
+        ],
+      },
+    ],
+  },
+  {
+    path: '/feastdayactivities/',
+    title: 'Catholic Feast Day Activities for Families | Claritas Studios',
+    description: 'Celebrate the Catholic liturgical year with free feast-day activities, printables, recipes, and prayer guides designed for families and classrooms.',
+    h1: 'Feast Day Activities',
+    intro: 'Celebrate the Catholic liturgical year at home or in the classroom. Each feast day includes a short reflection plus printable activities and family prayer ideas.',
+    sections: [
+      {
+        heading: 'Live the liturgical year',
+        paragraphs: [
+          'From Advent and Christmas to Lent and Easter, the Church’s calendar is full of opportunities to teach the faith through celebration.',
+        ],
+        links: [
+          { href: '/saints/', label: 'Lives of the Saints' },
+          { href: '/resources/', label: 'All resources' },
+        ],
+      },
+    ],
+  },
+];

--- a/scripts/verify-seo.mjs
+++ b/scripts/verify-seo.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/*
+ * SEO smoke test for prerendered routes.
+ *
+ * Reads every route emitted by `scripts/prerender-routes.mjs` from `dist/`
+ * and asserts:
+ *   - one <title> tag with non-empty text
+ *   - one meta description with non-empty content
+ *   - exactly one canonical link
+ *   - at least one H1
+ *   - at least one internal link in raw HTML
+ *   - title and canonical agree with the route definition
+ *
+ * Exits non-zero on any failure so this can run in CI.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { ROUTES, SITE_ORIGIN } from './seo-routes.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const distDir = resolve(__dirname, '..', 'dist');
+
+function fileFor(route) {
+  return route.path === '/'
+    ? resolve(distDir, 'index.html')
+    : resolve(distDir, route.path.replace(/^\/+|\/+$/g, ''), 'index.html');
+}
+
+function countMatches(re, html) {
+  return (html.match(re) || []).length;
+}
+
+const failures = [];
+
+for (const route of ROUTES) {
+  const file = fileFor(route);
+  const display = route.path;
+
+  if (!existsSync(file)) {
+    failures.push(`${display}: missing prerendered file ${file}`);
+    continue;
+  }
+
+  const html = readFileSync(file, 'utf8');
+
+  // <title>
+  const titleMatch = html.match(/<title>([\s\S]*?)<\/title>/i);
+  if (!titleMatch || !titleMatch[1].trim()) {
+    failures.push(`${display}: missing <title>`);
+  } else if (titleMatch[1].trim() !== route.title) {
+    failures.push(`${display}: <title> "${titleMatch[1].trim()}" does not match route.title "${route.title}"`);
+  }
+  if (countMatches(/<title>/gi, html) !== 1) {
+    failures.push(`${display}: expected exactly one <title>`);
+  }
+
+  // meta description
+  const descMatch = html.match(/<meta\s+name="description"\s+content="([^"]*)"\s*\/?>/i);
+  if (!descMatch || !descMatch[1].trim()) {
+    failures.push(`${display}: missing meta description`);
+  }
+
+  // canonical
+  const canonicalMatches = html.match(/<link\s+rel="canonical"\s+href="([^"]+)"/gi) || [];
+  if (canonicalMatches.length !== 1) {
+    failures.push(`${display}: expected exactly one canonical link, got ${canonicalMatches.length}`);
+  } else {
+    const expected = `${SITE_ORIGIN}${route.path}`;
+    const actual = canonicalMatches[0].match(/href="([^"]+)"/)[1];
+    if (actual !== expected) {
+      failures.push(`${display}: canonical "${actual}" does not match expected "${expected}"`);
+    }
+  }
+
+  // H1
+  if (countMatches(/<h1[\s>]/gi, html) < 1) {
+    failures.push(`${display}: missing <h1>`);
+  }
+
+  // Internal link
+  if (!/<a\s+[^>]*href="\/[^"]*"/i.test(html)) {
+    failures.push(`${display}: no internal links in raw HTML`);
+  }
+
+  // Meaningful text: presence of intro string
+  if (!html.includes(route.intro)) {
+    failures.push(`${display}: route intro text not found in raw HTML`);
+  }
+}
+
+if (failures.length) {
+  console.error(`[verify-seo] ${failures.length} failure(s):`);
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+
+console.log(`[verify-seo] OK — ${ROUTES.length} routes pass all checks.`);


### PR DESCRIPTION
## Summary

Closes #34. Public routes are now crawlable in raw HTML (no JS execution required). Build-time prerendering writes one static `index.html` per public route with a route-specific `<title>`, meta description, canonical link, OG/Twitter tags, `<h1>`, primary navigation, and meaningful body copy. The Elm SPA still hydrates over the prerendered content for end users — no behavior change for visitors.

### Strategy

We chose **build-time prerendering** over SSG/SSR/prerender bridge because it is the least disruptive option for an Elm SPA on Netlify. Tradeoffs documented in `docs/SEO_PRERENDERING.md`.

### Changes

- `scripts/seo-routes.mjs` — single source of truth for route metadata (path, title, description, canonical, H1, intro copy, sections, links).
- `scripts/prerender-routes.mjs` — runs after `vite build`; rewrites `<title>`, meta description, OG tags; inserts canonical and Twitter tags; injects per-route H1, primary nav, and crawlable text inside `#elm-root`; writes `dist/<route>/index.html`.
- `scripts/verify-seo.mjs` — SEO smoke test. Asserts each route has exactly one `<title>` matching the route definition, one canonical link matching `https://claritasstudios.com<path>`, ≥1 `<h1>`, a non-empty meta description, ≥1 internal link, and the intro text. Run with `npm run verify:seo`. Non-zero exit on failure.
- `docs/SEO_PRERENDERING.md` — design rationale + how to add new routes.
- `public/static/sitemap.xml` — now lists all 15 prerendered routes (was 6).
- `public/static/robots.txt` — sitemap URL corrected to `https://claritasstudios.com/sitemap.xml`.
- `package.json` — `npm run build` now runs `vite build && npm run prerender`.

### Routes covered (15)

Required (per #34): `/`, `/animations/`, `/team/`, `/resources/`, `/give/`, `/contact/`, `/saints/`, `/prayers/`, `/feastdayactivities/`.

Animation series (discovered from `src/Page/Animations/Productions.elm`): `/animations/hailmary/`, `/animations/prayertimewithangels/`, `/animations/daisyandsheep/`, `/animations/songsofthesaints/`, `/animations/gigglesandgraceshow/`, `/animations/prayingwiththesaints/`.

Episode-detail pages and saint detail pages stay SPA-only (saint detail is intentionally `noindex`; episode URLs change frequently).

## Test plan

- [x] `npm install`
- [x] `npm run build` — vite + prerender both succeed; 15 files written to `dist/`.
- [x] `npm run verify:seo` — `[verify-seo] OK — 15 routes pass all checks.`
- [x] Manual `curl` against `python3 -m http.server` in `dist/` — every required route returns 200, raw HTML contains route-specific `<title>`, `<h1>`, meta description, canonical, and internal links.
- [ ] Confirm in production after Netlify deploy: `curl -L https://claritasstudios.com/animations/` shows new title and H1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)