### PR TITLE
Add full per-route metadata for OG/Twitter cards and unique titles (#35)

### DIFF
--- a/scripts/prerender-routes.mjs
+++ b/scripts/prerender-routes.mjs
@@ -17,7 +17,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { ROUTES, SITE_ORIGIN, NAV_LINKS } from './seo-routes.mjs';
+import { ROUTES, NAV_LINKS } from './seo-routes.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const distDir = resolve(__dirname, '..', 'dist');
@@ -85,56 +85,51 @@ function renderBodyContent(route) {
 }
 
 function renderRouteHtml(route) {
-  const canonical = `${SITE_ORIGIN}${route.path}`;
-  const title = route.title;
-  const description = route.description;
-  const ogImage = route.ogImage || `${SITE_ORIGIN}/assets/images/thumbnails/CSCThumbnail.png`;
-
   let html = baseHtml;
 
   // Replace <title>
-  html = html.replace(/<title>[\s\S]*?<\/title>/i, `<title>${escape(title)}</title>`);
+  html = html.replace(/<title>[\s\S]*?<\/title>/i, `<title>${escape(route.title)}</title>`);
 
   // Replace meta description
   html = html.replace(
     /<meta\s+name="description"[\s\S]*?>/i,
-    `<meta name="description" content="${escape(description)}">`,
+    `<meta name="description" content="${escape(route.description)}">`,
   );
 
   // Replace og:title
   html = html.replace(
     /<meta\s+property="og:title"[\s\S]*?>/i,
-    `<meta property="og:title" content="${escape(title)}">`,
+    `<meta property="og:title" content="${escape(route.ogTitle)}">`,
   );
 
   // Replace og:description
   html = html.replace(
     /<meta\s+property="og:description"[\s\S]*?>/i,
-    `<meta property="og:description" content="${escape(description)}">`,
+    `<meta property="og:description" content="${escape(route.ogDescription)}">`,
   );
 
-  // Replace og:url
+  // Replace og:url with the route's own URL (not the homepage)
   html = html.replace(
     /<meta\s+property="og:url"[\s\S]*?>/i,
-    `<meta property="og:url" content="${escape(canonical)}">`,
+    `<meta property="og:url" content="${escape(route.ogUrl)}">`,
   );
 
-  // Replace og:image / twitter:image when route overrides it
+  // Replace og:image and twitter:image
   html = html.replace(
     /<meta\s+property="og:image"[\s\S]*?>/i,
-    `<meta property="og:image" content="${escape(ogImage)}">`,
+    `<meta property="og:image" content="${escape(route.ogImage)}">`,
   );
   html = html.replace(
     /<meta\s+property="twitter:image"[\s\S]*?>/i,
-    `<meta property="twitter:image" content="${escape(ogImage)}">`,
+    `<meta property="twitter:image" content="${escape(route.twitterImage)}">`,
   );
 
-  // Add canonical link, twitter:title and twitter:description into <head>
+  // Add self-referential canonical link, twitter:title, and twitter:description.
   // (insert just before </head>)
   const headExtras = [
-    `  <link rel="canonical" href="${escape(canonical)}">`,
-    `  <meta property="twitter:title" content="${escape(title)}">`,
-    `  <meta property="twitter:description" content="${escape(description)}">`,
+    `  <link rel="canonical" href="${escape(route.canonical)}">`,
+    `  <meta property="twitter:title" content="${escape(route.twitterTitle)}">`,
+    `  <meta property="twitter:description" content="${escape(route.twitterDescription)}">`,
   ].join('\n');
   html = html.replace(/<\/head>/i, `${headExtras}\n</head>`);
 

--- a/scripts/seo-routes.mjs
+++ b/scripts/seo-routes.mjs
@@ -3,12 +3,21 @@
  *
  * Each entry produces one static `<path>/index.html` file at build time
  * with route-specific <title>, meta description, canonical link, OG tags,
- * H1, navigation, and crawlable text content.
+ * Twitter card tags, H1, navigation, and crawlable text content.
+ *
+ * Required per-route fields (issue #35):
+ *   path, title, description, canonical, ogTitle, ogDescription, ogUrl,
+ *   ogImage, twitterTitle, twitterDescription, twitterImage, h1
+ *
+ * Most of these are derived from `path`, `title`, and `description`. Use
+ * `buildRoute` to ensure the derived fields are filled in consistently.
  *
  * Edit this file when you add a new public route.
  */
 
 export const SITE_ORIGIN = 'https://claritasstudios.com';
+
+const DEFAULT_OG_IMAGE = `${SITE_ORIGIN}/assets/images/thumbnails/CSCThumbnail.png`;
 
 export const NAV_LINKS = [
   { href: '/', label: 'Home' },
@@ -29,6 +38,7 @@ const ANIMATION_SERIES = [
     description: 'Learn one of the most beautiful prayers in the Catholic tradition. A prayer of love and devotion to our Blessed Mother Mary.',
     age: 'Ages 2+',
     year: '2020',
+    image: '/assets/images/CarouselThumbnails/HailMary.png',
   },
   {
     slug: 'prayertimewithangels',
@@ -36,6 +46,7 @@ const ANIMATION_SERIES = [
     description: 'Join Theo and Felicity as they learn common Catholic prayers from their guardian angels.',
     age: 'Ages 6+',
     year: '2023',
+    image: '/assets/images/CarouselThumbnails/PrayerTimeWithAngels.png',
   },
   {
     slug: 'daisyandsheep',
@@ -43,6 +54,7 @@ const ANIMATION_SERIES = [
     description: 'Join Daisy and Sheep as they learn about the Mass one part at a time and discover fun facts about the Catholic Church.',
     age: 'Ages 10+',
     year: '2024',
+    image: '/assets/images/CarouselThumbnails/DaisyAndSheep.png',
   },
   {
     slug: 'songsofthesaints',
@@ -50,6 +62,7 @@ const ANIMATION_SERIES = [
     description: 'Sing along with your favorite saints in this musical journey.',
     age: 'Ages 10+',
     year: '2025',
+    image: '/assets/images/CarouselThumbnails/SongsOfTheSaints.png',
   },
   {
     slug: 'gigglesandgraceshow',
@@ -57,6 +70,7 @@ const ANIMATION_SERIES = [
     description: 'A musical animated short film that celebrates the joy of thanking God even when things go wrong.',
     age: 'Ages 2+',
     year: '2025',
+    image: '/assets/images/CarouselThumbnails/GigglesAndGrace.webp',
   },
   {
     slug: 'prayingwiththesaints',
@@ -64,14 +78,43 @@ const ANIMATION_SERIES = [
     description: 'Pray common prayers with the saints in this collection of 12 videos featuring St. Thérèse of Lisieux and Carlo Acutis.',
     age: 'Ages 6+',
     year: '2025',
+    image: '/assets/images/CarouselThumbnails/PrayingWithTheSaints.png',
   },
 ];
 
-function animationSeriesRoute(series) {
+/**
+ * Fills in derived metadata fields. Per-route overrides win; everything else
+ * is derived from path/title/description so a route author only has to write
+ * the unique copy.
+ */
+function buildRoute(route) {
+  const url = `${SITE_ORIGIN}${route.path}`;
+  const title = route.title;
+  const description = route.description;
+  const ogImage = route.ogImage
+    ? (route.ogImage.startsWith('http') ? route.ogImage : `${SITE_ORIGIN}${route.ogImage}`)
+    : DEFAULT_OG_IMAGE;
   return {
+    ...route,
+    canonical: route.canonical || url,
+    ogTitle: route.ogTitle || title,
+    ogDescription: route.ogDescription || description,
+    ogUrl: route.ogUrl || url,
+    ogImage,
+    twitterTitle: route.twitterTitle || route.ogTitle || title,
+    twitterDescription: route.twitterDescription || route.ogDescription || description,
+    twitterImage: route.twitterImage
+      ? (route.twitterImage.startsWith('http') ? route.twitterImage : `${SITE_ORIGIN}${route.twitterImage}`)
+      : ogImage,
+  };
+}
+
+function animationSeriesRoute(series) {
+  return buildRoute({
     path: `/animations/${series.slug}/`,
     title: `${series.title} | Catholic Animations | Claritas Studios`,
     description: series.description,
+    ogImage: series.image,
     h1: series.title,
     intro: `${series.description} ${series.age}. Released ${series.year}.`,
     sections: [
@@ -86,10 +129,10 @@ function animationSeriesRoute(series) {
         ],
       },
     ],
-  };
+  });
 }
 
-export const ROUTES = [
+const RAW_ROUTES = [
   {
     path: '/',
     title: 'Free Catholic Animations for Children | Claritas Studios',
@@ -155,7 +198,6 @@ export const ROUTES = [
       },
     ],
   },
-  ...ANIMATION_SERIES.map(animationSeriesRoute),
   {
     path: '/team/',
     title: 'About Our Catholic Animation Nonprofit | Claritas Studios',
@@ -183,7 +225,7 @@ export const ROUTES = [
   },
   {
     path: '/resources/',
-    title: 'Catholic Resources for Parents and Teachers | Claritas Studios',
+    title: 'Catholic Resources for Families | Claritas Studios',
     description: 'Free Catholic resources for parents, catechists, and teachers: printable activities, prayer guides, saint biographies, and feast-day worksheets.',
     h1: 'Resources for Parents and Teachers',
     intro: 'Free downloadable Catholic resources from Claritas Studios. Use these printables and guides at home, in the classroom, or in your parish faith-formation program.',
@@ -204,7 +246,7 @@ export const ROUTES = [
   },
   {
     path: '/give/',
-    title: 'Donate to Claritas Studios | Support Catholic Animation for Children',
+    title: 'Donate to Free Catholic Animations | Claritas Studios',
     description: 'Make a tax-deductible donation to Claritas Studios. Your gift funds free Catholic animations, prayers, and resources for families around the world.',
     h1: 'Support Claritas Studios',
     intro: 'Claritas Studios is a 501(c)(3) Catholic nonprofit. Donations are tax-deductible and directly fund the production of new animations and free resources.',
@@ -229,8 +271,8 @@ export const ROUTES = [
   },
   {
     path: '/contact/',
-    title: 'Contact Claritas Studios | Catholic Animation Studio',
-    description: 'Get in touch with Claritas Studios. We welcome partnership, press, and parish inquiries about our Catholic animations and resources.',
+    title: 'Contact Claritas Studios',
+    description: 'Get in touch with Claritas Studios. We welcome partnership, press, and parish inquiries about our Catholic animations and resources for children.',
     h1: 'Contact Claritas Studios',
     intro: 'We love hearing from families, parishes, and schools who use our animations. Reach out with questions, partnership ideas, or press inquiries.',
     sections: [
@@ -292,6 +334,7 @@ export const ROUTES = [
     description: 'Celebrate the Catholic liturgical year with free feast-day activities, printables, recipes, and prayer guides designed for families and classrooms.',
     h1: 'Feast Day Activities',
     intro: 'Celebrate the Catholic liturgical year at home or in the classroom. Each feast day includes a short reflection plus printable activities and family prayer ideas.',
+    ogImage: '/assets/images/thumbnails/FeastDayActivityThumbnail.png',
     sections: [
       {
         heading: 'Live the liturgical year',
@@ -305,4 +348,9 @@ export const ROUTES = [
       },
     ],
   },
+];
+
+export const ROUTES = [
+  ...RAW_ROUTES.map(buildRoute),
+  ...ANIMATION_SERIES.map(animationSeriesRoute),
 ];

--- a/scripts/verify-seo.mjs
+++ b/scripts/verify-seo.mjs
@@ -3,13 +3,19 @@
  * SEO smoke test for prerendered routes.
  *
  * Reads every route emitted by `scripts/prerender-routes.mjs` from `dist/`
- * and asserts:
- *   - one <title> tag with non-empty text
- *   - one meta description with non-empty content
- *   - exactly one canonical link
+ * and asserts the acceptance criteria for issue #35:
+ *   - one <title> tag whose text matches `route.title`
+ *   - one meta description matching `route.description`
+ *   - exactly one self-referential canonical link
+ *   - og:title, og:description, og:url, og:image present and correct
+ *   - twitter:card, twitter:title, twitter:description, twitter:image present
+ *   - og:url is the route's own URL, never the homepage on inner pages
  *   - at least one H1
  *   - at least one internal link in raw HTML
- *   - title and canonical agree with the route definition
+ *
+ * Cross-route checks:
+ *   - every public route has a unique <title>
+ *   - every public route has a unique meta description
  *
  * Exits non-zero on any failure so this can run in CI.
  */
@@ -33,7 +39,27 @@ function countMatches(re, html) {
   return (html.match(re) || []).length;
 }
 
+function metaContent(html, attr, name) {
+  // Match `<meta {attr}="{name}" ... content="...">` regardless of attribute order.
+  const re = new RegExp(
+    `<meta\\s+(?=[^>]*\\b${attr}="${name}")[^>]*\\bcontent="([^"]*)"[^>]*>`,
+    'i',
+  );
+  const m = html.match(re);
+  return m ? m[1] : null;
+}
+
+function metaTagCount(html, attr, name) {
+  const re = new RegExp(
+    `<meta\\s+(?=[^>]*\\b${attr}="${name}")[^>]*>`,
+    'gi',
+  );
+  return (html.match(re) || []).length;
+}
+
 const failures = [];
+const titlesSeen = new Map();
+const descriptionsSeen = new Map();
 
 for (const route of ROUTES) {
   const file = fileFor(route);
@@ -50,20 +76,40 @@ for (const route of ROUTES) {
   const titleMatch = html.match(/<title>([\s\S]*?)<\/title>/i);
   if (!titleMatch || !titleMatch[1].trim()) {
     failures.push(`${display}: missing <title>`);
-  } else if (titleMatch[1].trim() !== route.title) {
-    failures.push(`${display}: <title> "${titleMatch[1].trim()}" does not match route.title "${route.title}"`);
+  } else {
+    const titleText = titleMatch[1].trim();
+    if (titleText !== route.title) {
+      failures.push(`${display}: <title> "${titleText}" does not match route.title "${route.title}"`);
+    }
+    if (titlesSeen.has(titleText)) {
+      failures.push(`${display}: duplicate <title> "${titleText}" — also used by ${titlesSeen.get(titleText)}`);
+    } else {
+      titlesSeen.set(titleText, display);
+    }
   }
   if (countMatches(/<title>/gi, html) !== 1) {
     failures.push(`${display}: expected exactly one <title>`);
   }
 
   // meta description
-  const descMatch = html.match(/<meta\s+name="description"\s+content="([^"]*)"\s*\/?>/i);
-  if (!descMatch || !descMatch[1].trim()) {
+  const desc = metaContent(html, 'name', 'description');
+  if (!desc || !desc.trim()) {
     failures.push(`${display}: missing meta description`);
+  } else {
+    if (desc !== route.description) {
+      failures.push(`${display}: meta description does not match route.description`);
+    }
+    if (descriptionsSeen.has(desc)) {
+      failures.push(`${display}: duplicate meta description — also used by ${descriptionsSeen.get(desc)}`);
+    } else {
+      descriptionsSeen.set(desc, display);
+    }
+  }
+  if (metaTagCount(html, 'name', 'description') !== 1) {
+    failures.push(`${display}: expected exactly one meta description`);
   }
 
-  // canonical
+  // canonical (self-referential, exactly one)
   const canonicalMatches = html.match(/<link\s+rel="canonical"\s+href="([^"]+)"/gi) || [];
   if (canonicalMatches.length !== 1) {
     failures.push(`${display}: expected exactly one canonical link, got ${canonicalMatches.length}`);
@@ -73,6 +119,56 @@ for (const route of ROUTES) {
     if (actual !== expected) {
       failures.push(`${display}: canonical "${actual}" does not match expected "${expected}"`);
     }
+    if (actual !== route.canonical) {
+      failures.push(`${display}: canonical "${actual}" does not match route.canonical "${route.canonical}"`);
+    }
+  }
+
+  // Open Graph metadata
+  const ogTitle = metaContent(html, 'property', 'og:title');
+  if (ogTitle !== route.ogTitle) {
+    failures.push(`${display}: og:title "${ogTitle}" does not match route.ogTitle "${route.ogTitle}"`);
+  }
+  const ogDescription = metaContent(html, 'property', 'og:description');
+  if (ogDescription !== route.ogDescription) {
+    failures.push(`${display}: og:description does not match route.ogDescription`);
+  }
+  const ogUrl = metaContent(html, 'property', 'og:url');
+  if (ogUrl !== route.ogUrl) {
+    failures.push(`${display}: og:url "${ogUrl}" does not match route.ogUrl "${route.ogUrl}"`);
+  }
+  if (route.path !== '/' && ogUrl === SITE_ORIGIN + '/') {
+    failures.push(`${display}: og:url points to homepage instead of the route URL`);
+  }
+  const ogImage = metaContent(html, 'property', 'og:image');
+  if (!ogImage) {
+    failures.push(`${display}: missing og:image`);
+  } else if (ogImage !== route.ogImage) {
+    failures.push(`${display}: og:image "${ogImage}" does not match route.ogImage "${route.ogImage}"`);
+  }
+
+  // Twitter card metadata
+  const twitterCard = metaContent(html, 'property', 'twitter:card')
+    || metaContent(html, 'name', 'twitter:card');
+  if (!twitterCard) {
+    failures.push(`${display}: missing twitter:card`);
+  }
+  const twitterTitle = metaContent(html, 'property', 'twitter:title')
+    || metaContent(html, 'name', 'twitter:title');
+  if (twitterTitle !== route.twitterTitle) {
+    failures.push(`${display}: twitter:title "${twitterTitle}" does not match route.twitterTitle "${route.twitterTitle}"`);
+  }
+  const twitterDescription = metaContent(html, 'property', 'twitter:description')
+    || metaContent(html, 'name', 'twitter:description');
+  if (twitterDescription !== route.twitterDescription) {
+    failures.push(`${display}: twitter:description does not match route.twitterDescription`);
+  }
+  const twitterImage = metaContent(html, 'property', 'twitter:image')
+    || metaContent(html, 'name', 'twitter:image');
+  if (!twitterImage) {
+    failures.push(`${display}: missing twitter:image`);
+  } else if (twitterImage !== route.twitterImage) {
+    failures.push(`${display}: twitter:image "${twitterImage}" does not match route.twitterImage "${route.twitterImage}"`);
   }
 
   // H1
@@ -97,4 +193,4 @@ if (failures.length) {
   process.exit(1);
 }
 
-console.log(`[verify-seo] OK — ${ROUTES.length} routes pass all checks.`);
+console.log(`[verify-seo] OK — ${ROUTES.length} routes pass all checks (titles, descriptions, canonicals, OG, Twitter).`);


### PR DESCRIPTION
## Summary

Closes #35. Builds on the prerendering foundation merged in #44.

- Single source-of-truth metadata schema in `scripts/seo-routes.mjs` now covers every field listed in the issue: `path`, `title`, `description`, `canonical`, `ogTitle`, `ogDescription`, `ogUrl`, `ogImage`, `twitterTitle`, `twitterDescription`, `twitterImage`, and `h1`. A `buildRoute` helper derives the OG / Twitter / canonical fields from `path` + `title` + `description` so route authors only write the unique copy; per-route overrides win.
- `scripts/prerender-routes.mjs` now writes a route-specific `og:url` (no longer the homepage on inner pages), a self-referential `<link rel="canonical">`, route-specific `og:image` / `twitter:image` (animation series get their own thumbnails), and `twitter:title` / `twitter:description`.
- `scripts/verify-seo.mjs` enforces the issue's acceptance criteria: each route has a unique `<title>` and meta description, exactly one self-referential canonical, full OG and Twitter card metadata that matches the route definition, and `og:url` that is never the homepage on inner pages.
- Applied the suggested titles from the issue (Home, Animations, Team, Resources, Give, Contact). The `/resources/` page is now titled `Catholic Resources for Families | Claritas Studios` to match the issue.

## Acceptance criteria

- [x] Every public route has a unique `<title>`.
- [x] Every public route has a unique meta description.
- [x] Every indexable public route has one self-referential canonical tag.
- [x] `og:url` matches the current route, not the homepage, on inner pages.
- [x] Twitter/X card title and description are present per route.
- [x] Metadata is present in raw / pre-rendered HTML.

## Testing

```
$ npm run build
…
[prerender] Wrote 15 route files.

$ npm run verify:seo
[verify-seo] OK — 15 routes pass all checks (titles, descriptions, canonicals, OG, Twitter).
```

Spot-check on `dist/animations/hailmary/index.html`:

```
<title>Hail Mary | Catholic Animations | Claritas Studios</title>
<meta name="description" content="Learn one of the most beautiful prayers in the Catholic tradition. …">
<meta property="og:title" content="Hail Mary | Catholic Animations | Claritas Studios">
<meta property="og:url" content="https://claritasstudios.com/animations/hailmary/">
<meta property="og:image" content="https://claritasstudios.com/assets/images/CarouselThumbnails/HailMary.png">
<meta property="twitter:card" content="summary_large_image">
<meta property="twitter:title" content="Hail Mary | Catholic Animations | Claritas Studios">
<meta property="twitter:description" content="Learn one of the most beautiful prayers …">
<link rel="canonical" href="https://claritasstudios.com/animations/hailmary/">
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)