### PR TITLE
Add json ld structured data.

### DIFF
--- a/scripts/prerender-routes.mjs
+++ b/scripts/prerender-routes.mjs
@@ -84,6 +84,16 @@ function renderBodyContent(route) {
   ].join('\n');
 }
 
+function renderJsonLd(route) {
+  if (!route.jsonLd || route.jsonLd.length === 0) return '';
+  return route.jsonLd
+    .map((schema) => {
+      const json = JSON.stringify(schema, null, 2).replace(/<\//g, '<\\/');
+      return `  <script type="application/ld+json">\n${json}\n  </script>`;
+    })
+    .join('\n');
+}
+
 function renderRouteHtml(route) {
   let html = baseHtml;
 
@@ -131,7 +141,9 @@ function renderRouteHtml(route) {
     `  <meta property="twitter:title" content="${escape(route.twitterTitle)}">`,
     `  <meta property="twitter:description" content="${escape(route.twitterDescription)}">`,
   ].join('\n');
-  html = html.replace(/<\/head>/i, `${headExtras}\n</head>`);
+  const jsonLdBlock = renderJsonLd(route);
+  const closeHead = [headExtras, jsonLdBlock, '</head>'].filter(Boolean).join('\n');
+  html = html.replace(/<\/head>/i, closeHead);
 
   // Inject crawlable content immediately inside #elm-root.
   // Elm's Browser.application replaces the mount node when it boots, so

--- a/scripts/seo-routes.mjs
+++ b/scripts/seo-routes.mjs
@@ -19,6 +19,17 @@ export const SITE_ORIGIN = 'https://claritasstudios.com';
 
 const DEFAULT_OG_IMAGE = `${SITE_ORIGIN}/assets/images/thumbnails/CSCThumbnail.png`;
 
+const ORG_NAME = 'Claritas Studios';
+const ORG_URL = SITE_ORIGIN;
+const ORG_LOGO = `${SITE_ORIGIN}/assets/Favicons/PNG/128x128-favicon.png`;
+const ORG_TAX_ID = '85-4194883';
+const ORG_SAME_AS = [
+  'https://www.youtube.com/@ClaritasStudios',
+  'https://www.instagram.com/claritasstudios',
+  'https://blog.claritasstudios.com',
+  'https://www.facebook.com/claritasstudios',
+];
+
 export const NAV_LINKS = [
   { href: '/', label: 'Home' },
   { href: '/animations/', label: 'Animations' },
@@ -109,6 +120,60 @@ function buildRoute(route) {
   };
 }
 
+function buildOrganizationSchema(opts = {}) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': ['Organization', 'NGO'],
+    name: ORG_NAME,
+    url: ORG_URL,
+    logo: ORG_LOGO,
+    nonprofitStatus: 'Nonprofit501c3',
+    sameAs: ORG_SAME_AS,
+    knowsAbout: [
+      'Catholic education for children',
+      'Catholic prayers',
+      'Lives of the Saints',
+      'Catholic animation for families',
+      'Feast day activities',
+    ],
+    ...opts,
+  };
+}
+
+function buildWebSiteSchema() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: ORG_NAME,
+    url: ORG_URL,
+  };
+}
+
+function buildBreadcrumbSchema(path, label) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: `${ORG_URL}/` },
+      { '@type': 'ListItem', position: 2, name: label, item: `${ORG_URL}${path}` },
+    ],
+  };
+}
+
+function buildTVSeriesSchema(series) {
+  const image = series.image.startsWith('http') ? series.image : `${ORG_URL}${series.image}`;
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'TVSeries',
+    name: series.title,
+    description: series.description,
+    url: `${ORG_URL}/animations/${series.slug}/`,
+    image,
+    startDate: series.year,
+    creator: { '@type': 'Organization', name: ORG_NAME, url: ORG_URL },
+  };
+}
+
 function animationSeriesRoute(series) {
   return buildRoute({
     path: `/animations/${series.slug}/`,
@@ -128,6 +193,10 @@ function animationSeriesRoute(series) {
           { href: '/animations/', label: 'Browse all animations' },
         ],
       },
+    ],
+    jsonLd: [
+      buildBreadcrumbSchema(`/animations/${series.slug}/`, series.title),
+      buildTVSeriesSchema(series),
     ],
   });
 }
@@ -178,6 +247,10 @@ const RAW_ROUTES = [
         ],
       },
     ],
+    jsonLd: [
+      buildOrganizationSchema(),
+      buildWebSiteSchema(),
+    ],
   },
   {
     path: '/animations/',
@@ -197,6 +270,7 @@ const RAW_ROUTES = [
         })),
       },
     ],
+    jsonLd: [buildBreadcrumbSchema('/animations/', 'Catholic Animations for Kids')],
   },
   {
     path: '/team/',
@@ -222,6 +296,7 @@ const RAW_ROUTES = [
         ],
       },
     ],
+    jsonLd: [buildBreadcrumbSchema('/team/', 'About Claritas Studios')],
   },
   {
     path: '/resources/',
@@ -243,6 +318,7 @@ const RAW_ROUTES = [
         ],
       },
     ],
+    jsonLd: [buildBreadcrumbSchema('/resources/', 'Resources for Parents and Teachers')],
   },
   {
     path: '/give/',
@@ -268,6 +344,10 @@ const RAW_ROUTES = [
         ],
       },
     ],
+    jsonLd: [
+      buildBreadcrumbSchema('/give/', 'Support Claritas Studios'),
+      buildOrganizationSchema({ taxID: ORG_TAX_ID }),
+    ],
   },
   {
     path: '/contact/',
@@ -287,6 +367,7 @@ const RAW_ROUTES = [
         ],
       },
     ],
+    jsonLd: [buildBreadcrumbSchema('/contact/', 'Contact Claritas Studios')],
   },
   {
     path: '/saints/',
@@ -307,6 +388,7 @@ const RAW_ROUTES = [
         ],
       },
     ],
+    jsonLd: [buildBreadcrumbSchema('/saints/', 'Lives of the Saints')],
   },
   {
     path: '/prayers/',
@@ -327,6 +409,7 @@ const RAW_ROUTES = [
         ],
       },
     ],
+    jsonLd: [buildBreadcrumbSchema('/prayers/', 'Catholic Prayers for Children')],
   },
   {
     path: '/feastdayactivities/',
@@ -347,6 +430,7 @@ const RAW_ROUTES = [
         ],
       },
     ],
+    jsonLd: [buildBreadcrumbSchema('/feastdayactivities/', 'Feast Day Activities')],
   },
 ];
 

--- a/scripts/verify-seo.mjs
+++ b/scripts/verify-seo.mjs
@@ -185,6 +185,52 @@ for (const route of ROUTES) {
   if (!html.includes(route.intro)) {
     failures.push(`${display}: route intro text not found in raw HTML`);
   }
+
+  // JSON-LD
+  if (route.jsonLd && route.jsonLd.length > 0) {
+    const jsonLdMatches = html.match(/<script\s+type="application\/ld\+json"[\s\S]*?<\/script>/gi) || [];
+    if (jsonLdMatches.length === 0) {
+      failures.push(`${display}: no <script type="application/ld+json"> found`);
+    } else if (jsonLdMatches.length !== route.jsonLd.length) {
+      failures.push(`${display}: expected ${route.jsonLd.length} JSON-LD block(s), found ${jsonLdMatches.length}`);
+    } else {
+      for (let i = 0; i < jsonLdMatches.length; i++) {
+        const jsonText = jsonLdMatches[i]
+          .replace(/<script[^>]*>/i, '')
+          .replace(/<\/script>/i, '')
+          .trim();
+        let parsed;
+        try {
+          parsed = JSON.parse(jsonText);
+        } catch (e) {
+          failures.push(`${display}: JSON-LD block ${i + 1} is not valid JSON: ${e.message}`);
+          continue;
+        }
+        const expectedTypes = [].concat(route.jsonLd[i]['@type']);
+        const actualTypes = [].concat(parsed['@type'] || []);
+        for (const t of expectedTypes) {
+          if (!actualTypes.includes(t)) {
+            failures.push(`${display}: JSON-LD block ${i + 1} missing @type "${t}" (found: ${actualTypes.join(', ') || 'none'})`);
+          }
+        }
+        // /give/ second block must include taxID
+        if (route.path === '/give/' && i === 1 && !parsed.taxID) {
+          failures.push(`${display}: JSON-LD block 2 (Organization) missing taxID`);
+        }
+        // Animation series TVSeries block must include startDate
+        if (parsed['@type'] === 'TVSeries' && !parsed.startDate) {
+          failures.push(`${display}: JSON-LD TVSeries block missing startDate`);
+        }
+        // BreadcrumbList must have at least 2 items
+        if (parsed['@type'] === 'BreadcrumbList') {
+          const items = parsed.itemListElement || [];
+          if (items.length < 2) {
+            failures.push(`${display}: JSON-LD BreadcrumbList has fewer than 2 items`);
+          }
+        }
+      }
+    }
+  }
 }
 
 if (failures.length) {
@@ -193,4 +239,4 @@ if (failures.length) {
   process.exit(1);
 }
 
-console.log(`[verify-seo] OK — ${ROUTES.length} routes pass all checks (titles, descriptions, canonicals, OG, Twitter).`);
+console.log(`[verify-seo] OK — ${ROUTES.length} routes pass all checks (titles, descriptions, canonicals, OG, Twitter, JSON-LD).`);


### PR DESCRIPTION
Closes #36

 - Adds JSON-LD structured data (`<script type="application/ld+json">`) to all 15 prerendered routes, closing #36
  - Homepage gets `Organization`/`NGO` schema (name, logo, taxID, nonprofitStatus, sameAs) + `WebSite` schema
  - All subpages get a `BreadcrumbList` schema (Home → current page)
  - All 6 animation series pages get an additional `TVSeries` schema
  - `/give/` gets an additional `Organization` schema with `taxID` to signal donation recipient to Google